### PR TITLE
Better separation of raw and html message downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The cookies should look like this, where `someLongText` and `someShortText` are 
 
 In Google Chrome these steps are required:
 1. Go to [Yahoo Groups](https://groups.yahoo.com/neo).
-2. Click the 🔒 padlock, or ⓘ (cicled letter i) in the address bar to the left of the website address.
+2. Click the 🔒 padlock, or ⓘ (circled letter i) in the address bar to the left of the website address.
 3. Click "Cookies".
 4. On the Allowed tab select "Yahoo.com" followed by "Cookies" in the tree listing.
 5. Select the T cookie and copy the Content field in place of `<T_cookie>` in the above command line.
@@ -62,7 +62,7 @@ Files will be placed into the directory structure groupname/{email,files,photos,
 ## Command Line Options
 ```
 usage: yahoo.py [-h] [-ct COOKIE_T] [-cy COOKIE_Y] [-ce COOKIE_E]
-                [-cf COOKIE_FILE] [-e] [-at] [-f] [-i] [-t] [-tr] [-d] [-l]
+                [-cf COOKIE_FILE] [-e] [-at] [-f] [-i] [-t] [-r] [-d] [-l]
                 [-c] [-p] [-a] [-m] [-o] [--user-agent USER_AGENT]
                 [--start START] [--stop STOP] [--ids IDS [IDS ...]] [-w] [-v]
                 [--colour] [--delay DELAY]
@@ -96,10 +96,10 @@ What to archive:
   -at, --attachments    Only archive attachments (from attachments list)
   -f, --files           Only archive files
   -i, --photos          Only archive photo galleries
-  -t, --topics          Only archive HTML email and attachments through the
-                        topics API
-  -tr, --topicsWithRaw  Only archive both HTML and raw email and attachments
-                        through the topics API
+  -t, --topics          Only archive HTML email and attachments through 
+                        the topics API
+  -r, --raw             Only archive raw email without attachments through 
+                        the messages API
   -d, --database        Only archive database
   -l, --links           Only archive links
   -c, --calendar        Only archive events

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Authentication Options:
 What to archive:
   By default, all the below.
 
-  -e, --email           Only archive email and attachments (from email)
+  -e, --email           Only archive html and raw email and attachments (from email) 
+                        through the messages API
   -at, --attachments    Only archive attachments (from attachments list)
   -f, --files           Only archive files
   -i, --photos          Only archive photo galleries

--- a/yahoo.py
+++ b/yahoo.py
@@ -847,7 +847,7 @@ if __name__ == "__main__":
     po.add_argument('-t', '--topics', action='store_true',
                     help='Only archive HTML email and attachments through the topics API')
     po.add_argument('-r', '--raw', action='store_true',
-                    help='Only archive raw email without attachemnts through the messages API')
+                    help='Only archive raw email without attachments through the messages API')
     po.add_argument('-d', '--database', action='store_true',
                     help='Only archive database')
     po.add_argument('-l', '--links', action='store_true',


### PR DESCRIPTION
Remove -tr flag.
Add -r flag (raw messages only through messages API).
Default when not specifying what to download is -t and -r but not -e. That should get each message in html and raw format exactly once.