### PR TITLE
Make Dockerfile download and install on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM python:3.8.0-alpine3.10
 
-COPY . /yga
-WORKDIR /yga
-
-RUN apk add rsync
-
-RUN pip3 install -r requirements.txt
+RUN apk --no-cache add rsync git
+COPY docker-startup.sh .
 
 ENV DOWNLOADER="Not_The_Googlebot"
 ENV CONCURRENT_ITEMS="1"
 
-ENTRYPOINT run-pipeline3 ./pipeline.py "$DOWNLOADER" --address 0.0.0.0 --concurrent "$CONCURRENT_ITEMS"
+ENTRYPOINT . docker-startup.sh && run-pipeline3 ./pipeline.py "$DOWNLOADER" --address 0.0.0.0 --concurrent "$CONCURRENT_ITEMS"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk --no-cache add rsync git
 COPY docker-startup.sh .
 
 ENV DOWNLOADER="Not_The_Googlebot"
-ENV CONCURRENT_ITEMS="3"
+ENV CONCURRENT_ITEMS="4"
 
 ENTRYPOINT . docker-startup.sh && run-pipeline3 ./pipeline.py "$DOWNLOADER" --address 0.0.0.0 --concurrent "$CONCURRENT_ITEMS"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk --no-cache add rsync git
 COPY docker-startup.sh .
 
 ENV DOWNLOADER="Not_The_Googlebot"
-ENV CONCURRENT_ITEMS="1"
+ENV CONCURRENT_ITEMS="3"
 
 ENTRYPOINT . docker-startup.sh && run-pipeline3 ./pipeline.py "$DOWNLOADER" --address 0.0.0.0 --concurrent "$CONCURRENT_ITEMS"

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,0 +1,3 @@
+git clone https://github.com/ArchiveTeam/yahoo-group-archiver
+cd yahoo-group-archiver
+pip3 install -r requirements.txt


### PR DESCRIPTION
This would mean that any changes will be reflected on restart of the container, at the expense of a long startup time.

Warrior does this as well to avoid having to update the image regularly.